### PR TITLE
[IAC-1677] Replace gofmt with goimports

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -37,6 +37,8 @@ jobs:
       - run:
           command: |
             pip install pre-commit==1.21.0 cfgv==2.0.1 zipp==1.1.0 yapf
+            go get golang.org/x/tools/cmd/goimports
+            export GOPATH=~/go/bin && export PATH=$PATH:$GOPATH 
             pre-commit install
             pre-commit run --all-files
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,5 +3,5 @@ repos:
     rev: v0.1.10
     hooks:
       - id: terraform-fmt
-      - id: gofmt
+      - id: goimports
 

--- a/test/http_test.go
+++ b/test/http_test.go
@@ -2,13 +2,13 @@ package test
 
 import (
 	"fmt"
+	"strings"
+	"testing"
+
 	"github.com/gruntwork-io/terratest/modules/gcp"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/gruntwork-io/terratest/modules/test-structure"
-	"strings"
-	"testing"
 )
 
 const OUTPUT_HTTP_LB_IP = "load_balancer_ip_address"

--- a/test/ilb_test.go
+++ b/test/ilb_test.go
@@ -2,14 +2,14 @@ package test
 
 import (
 	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
 	"github.com/gruntwork-io/terratest/modules/gcp"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/gruntwork-io/terratest/modules/test-structure"
-	"path/filepath"
-	"strings"
-	"testing"
 )
 
 const OUTPUT_PROXY_IP = "proxy_public_ip_address"

--- a/test/nlb_test.go
+++ b/test/nlb_test.go
@@ -2,14 +2,14 @@ package test
 
 import (
 	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
 	"github.com/gruntwork-io/terratest/modules/gcp"
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/gruntwork-io/terratest/modules/test-structure"
-	"path/filepath"
-	"strings"
-	"testing"
 )
 
 const OUTPUT_NLB_IP = "load_balancer_ip_address"

--- a/test/test_util.go
+++ b/test/test_util.go
@@ -3,15 +3,16 @@ package test
 import (
 	"crypto/tls"
 	"fmt"
-	"github.com/gruntwork-io/terratest/modules/gcp"
-	"github.com/gruntwork-io/terratest/modules/logger"
-	"github.com/gruntwork-io/terratest/modules/retry"
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"net/http"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/gruntwork-io/terratest/modules/gcp"
+	"github.com/gruntwork-io/terratest/modules/logger"
+	"github.com/gruntwork-io/terratest/modules/retry"
+	"github.com/stretchr/testify/assert"
 )
 
 const ROOT_DOMAIN_NAME_FOR_TEST = "gcloud-test.com"


### PR DESCRIPTION
Replace gofmt with goimports in the pre-commit configuration. Note: This PR was opened using git-xargs.