### PR TITLE
Add missing options for healthchecks for internal loadbalancer

### DIFF
--- a/modules/internal-load-balancer/main.tf
+++ b/modules/internal-load-balancer/main.tf
@@ -71,8 +71,12 @@ resource "google_compute_region_backend_service" "default" {
 resource "google_compute_health_check" "tcp" {
   count = var.http_health_check ? 0 : 1
 
-  project = var.project
-  name    = "${var.name}-hc"
+  project             = var.project
+  name                = "${var.name}-hc"
+  check_interval_sec  = var.health_check_interval
+  unhealthy_threshold = var.health_check_unhealthy_threshold
+  healthy_threshold   = var.health_check_healthy_threshold
+  timeout_sec         = var.health_check_timeout
 
   tcp_health_check {
     port = var.health_check_port
@@ -82,11 +86,17 @@ resource "google_compute_health_check" "tcp" {
 resource "google_compute_health_check" "http" {
   count = var.http_health_check ? 1 : 0
 
-  project = var.project
-  name    = "${var.name}-hc"
+  project             = var.project
+  name                = "${var.name}-hc"
+  check_interval_sec  = var.health_check_interval
+  unhealthy_threshold = var.health_check_unhealthy_threshold
+  healthy_threshold   = var.health_check_healthy_threshold
+  timeout_sec         = var.health_check_timeout
 
   http_health_check {
-    port = var.health_check_port
+    port         = var.health_check_port
+    request_path = var.health_check_path
+
   }
 }
 

--- a/modules/internal-load-balancer/variables.tf
+++ b/modules/internal-load-balancer/variables.tf
@@ -110,3 +110,32 @@ variable "custom_labels" {
   type        = map(string)
   default     = {}
 }
+variable "health_check_healthy_threshold" {
+  description = "A so-far unhealthy instance will be marked healthy after this many consecutive successes. The default value is 2."
+  type        = number
+  default     = 2
+}
+
+variable "health_check_unhealthy_threshold" {
+  description = "A so-far healthy instance will be marked unhealthy after this many consecutive failures. The default value is 2."
+  type        = number
+  default     = 2
+}
+
+variable "health_check_interval" {
+  description = "How often (in seconds) to send a health check. Default is 5."
+  type        = number
+  default     = 5
+}
+
+variable "health_check_timeout" {
+  description = "How long (in seconds) to wait before claiming failure. The default value is 5 seconds. It is invalid for 'health_check_timeout' to have greater value than 'health_check_interval'"
+  type        = number
+  default     = 5
+}
+
+variable "health_check_path" {
+  description = "The request path of the HTTP health check request. The default value is '/'."
+  type        = string
+  default     = "/"
+}


### PR DESCRIPTION
To resolve #23 adds health check options (same ones as the network-load-balancer module) to the internal-load-balancer.  Just copy/paste honestly. Thank you for the review!

This should be fully backwards compatible, as all these variables are optional.

The following optional variables are added:

health_check_healthy_threshold
health_check_unhealthy_threshold
health_check_timeout
health_check_path
