### PR TITLE
Add Ubuntu image + remove gcloud update from CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,8 @@
 version: 2.1
 
 defaults: &defaults
-  machine: true
+  machine:
+    image: ubuntu-2004:202104-01
 
 env: &env
   environment:
@@ -56,14 +57,6 @@ jobs:
             gruntwork-install --module-name "git-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
             gruntwork-install --binary-name "terratest_log_parser" --repo "https://github.com/gruntwork-io/terratest" --tag "${TERRATEST_LOG_PARSER_VERSION}"
             configure-environment-for-gruntwork-module --go-src-path ./test --terraform-version ${TERRAFORM_VERSION} --terragrunt-version ${TERRAGRUNT_VERSION} --packer-version ${PACKER_VERSION} --go-version ${GOLANG_VERSION}
-
-      # Install external dependencies
-      - run:
-          name: update gcloud
-          command: |
-            sudo apt-get remove -y google-cloud-sdk
-            sudo /opt/google-cloud-sdk/bin/gcloud --quiet components update
-            sudo /opt/google-cloud-sdk/bin/gcloud --quiet components update beta
 
       - run:
           name: run tests

--- a/test/http_test.go
+++ b/test/http_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
-        "github.com/gruntwork-io/terratest/modules/test-structure"
+	"github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 const OUTPUT_HTTP_LB_IP = "load_balancer_ip_address"

--- a/test/http_test.go
+++ b/test/http_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+        "github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 const OUTPUT_HTTP_LB_IP = "load_balancer_ip_address"

--- a/test/http_test.go
+++ b/test/http_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/gruntwork-io/terratest/modules/test-structure"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 const OUTPUT_HTTP_LB_IP = "load_balancer_ip_address"

--- a/test/ilb_test.go
+++ b/test/ilb_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/gruntwork-io/terratest/modules/test-structure"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 const OUTPUT_PROXY_IP = "proxy_public_ip_address"

--- a/test/ilb_test.go
+++ b/test/ilb_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+        "github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 const OUTPUT_PROXY_IP = "proxy_public_ip_address"

--- a/test/ilb_test.go
+++ b/test/ilb_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
-        "github.com/gruntwork-io/terratest/modules/test-structure"
+	"github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 const OUTPUT_PROXY_IP = "proxy_public_ip_address"

--- a/test/nlb_test.go
+++ b/test/nlb_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
- 	"github.com/gruntwork-io/terratest/modules/test-structure"
+	"github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 const OUTPUT_NLB_IP = "load_balancer_ip_address"

--- a/test/nlb_test.go
+++ b/test/nlb_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
+ 	"github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 const OUTPUT_NLB_IP = "load_balancer_ip_address"

--- a/test/nlb_test.go
+++ b/test/nlb_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/gruntwork-io/terratest/modules/logger"
 	"github.com/gruntwork-io/terratest/modules/random"
 	"github.com/gruntwork-io/terratest/modules/terraform"
-	"github.com/gruntwork-io/terratest/modules/test-structure"
+	test_structure "github.com/gruntwork-io/terratest/modules/test-structure"
 )
 
 const OUTPUT_NLB_IP = "load_balancer_ip_address"


### PR DESCRIPTION
The python version that the machine executor was using before isn't compatible with the latest gcloud package. 

Python versions supported by the https://pypi.org/project/gcloud/:
<img width="176" alt="Screen Shot 2021-07-13 at 20 41 22" src="https://user-images.githubusercontent.com/9384479/125507392-81028a34-3d85-4d03-bd9b-bdae39198cfe.png">

This PR changes the machine image to use Ubuntu and removes the update job for `gcloud`. The current `gcloud` version for this image is 337.0.0 (2021-04-20) while the latest one is 348.0.0 (2021-07-13).
