### PR TITLE
Update f1-micro to e2-micro instance

### DIFF
--- a/examples/internal-load-balancer/main.tf
+++ b/examples/internal-load-balancer/main.tf
@@ -109,7 +109,7 @@ resource "google_compute_instance_group" "api" {
 resource "google_compute_instance" "api" {
   project      = var.project
   name         = "${var.name}-api-instance"
-  machine_type = "f1-micro"
+  machine_type = "e2-micro"
   zone         = var.zone
 
   # We're tagging the instance with the tag specified in the firewall rule
@@ -142,7 +142,7 @@ resource "google_compute_instance" "api" {
 resource "google_compute_instance" "proxy" {
   project      = var.project
   name         = "${var.name}-proxy-instance"
-  machine_type = "f1-micro"
+  machine_type = "e2-micro"
   zone         = var.zone
 
   # We're tagging the instance with the tag specified in the firewall rule

--- a/examples/network-load-balancer/main.tf
+++ b/examples/network-load-balancer/main.tf
@@ -57,7 +57,7 @@ module "lb" {
 resource "google_compute_instance" "api" {
   project      = var.project
   name         = "${var.name}-api-instance"
-  machine_type = "f1-micro"
+  machine_type = "e2-micro"
   zone         = var.zone
 
   # We're tagging the instance with the tag specified in the firewall rule

--- a/main.tf
+++ b/main.tf
@@ -262,7 +262,7 @@ resource "google_compute_instance_group" "api" {
 resource "google_compute_instance" "api" {
   project      = var.project
   name         = "${var.name}-instance"
-  machine_type = "f1-micro"
+  machine_type = "e2-micro"
   zone         = var.zone
 
   # We're tagging the instance with the tag specified in the firewall rule


### PR DESCRIPTION
I just got an email from GCP stating that the f1-micro is being retired from free tier access and needs to be updated to e2-micro. This PR makes that change.