### PR TITLE
Enabled http to https redirect

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -52,6 +52,7 @@ module "lb" {
   dns_record_ttl        = var.dns_record_ttl
   enable_http           = var.enable_http
   enable_ssl            = var.enable_ssl
+  enable_http_to_https_redirect = var.enable_http_to_https_redirect
   ssl_certificates      = google_compute_ssl_certificate.certificate.*.self_link
 
   custom_labels = var.custom_labels
@@ -310,3 +311,5 @@ resource "google_compute_firewall" "firewall" {
     ports    = ["5000"]
   }
 }
+
+

--- a/modules/http-load-balancer/variables.tf
+++ b/modules/http-load-balancer/variables.tf
@@ -40,6 +40,12 @@ variable "enable_http" {
   default     = true
 }
 
+variable "enable_http_to_https_redirect" {
+  description = "Set to true to enable http requests to be redirected to https. If set to 'true' enable_ssl should be set to true and enable_http to false"
+  type        = bool
+  default     = false
+}
+
 variable "create_dns_entries" {
   description = "If set to true, create a DNS A Record in Cloud DNS for each domain specified in 'custom_domain_names'."
   type        = bool

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,12 @@ variable "enable_http" {
   default     = true
 }
 
+variable "enable_http_to_https_redirect" {
+  description = "Set to true to enable http requests to be redirected to https. If set to 'true' enable_ssl should be set to true and enable_http to false"
+  type        = bool
+  default     = false
+}
+
 variable "static_content_bucket_location" {
   description = "Location of the bucket that will store the static content. Once a bucket has been created, its location can't be changed. See https://cloud.google.com/storage/docs/bucket-locations"
   type        = string


### PR DESCRIPTION
Developed the http_load_balancer to accept a new parameter to indicate whether http requests should be redirected to https. If enabled it creates a new load balancer that redirects the http requests to the https load balancer.